### PR TITLE
Migrate to use newtype-generics & enable testsuite

### DIFF
--- a/dual-tree.cabal
+++ b/dual-tree.cabal
@@ -52,3 +52,14 @@ library
                      TypeOperators,
                      FlexibleContexts,
                      DeriveDataTypeable
+test-suite test
+  default-language:  Haskell2010
+  type:              exitcode-stdio-1.0
+  main-is:           Test.hs
+  hs-source-dirs:    test
+  ghc-options:       -Wall
+  build-depends:     base,
+                     QuickCheck,
+                     testing-feat,
+                     monoid-extras,
+                     dual-tree

--- a/dual-tree.cabal
+++ b/dual-tree.cabal
@@ -42,7 +42,7 @@ library
                      Data.Tree.DUAL.Internal
   build-depends:     base >= 4.3 && < 4.10,
                      semigroups >= 0.8 && < 0.19,
-                     newtype >= 0.2 && < 0.3,
+                     newtype-generics >= 0.5 && < 0.6,
                      monoid-extras >= 0.2 && < 0.5
   hs-source-dirs:    src
   other-extensions:  GeneralizedNewtypeDeriving,

--- a/src/Data/Tree/DUAL/Internal.hs
+++ b/src/Data/Tree/DUAL/Internal.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -83,7 +84,8 @@ instance (Action d u, Semigroup u) => Semigroup (DUALTreeNE d u a l) where
 
 newtype DAct d = DAct { unDAct :: d }
 
-instance Newtype (DAct d) d where
+instance Newtype (DAct d) where
+  type O (DAct d) = d
   pack   = DAct
   unpack = unDAct
 
@@ -101,7 +103,8 @@ instance (Semigroup d, Semigroup u, Action d u)
 newtype DUALTreeU d u a l = DUALTreeU { unDUALTreeU :: (u, DUALTreeNE d u a l) }
   deriving (Functor, Semigroup, Typeable, Show, Eq)
 
-instance Newtype (DUALTreeU d u a l) (u, DUALTreeNE d u a l) where
+instance Newtype (DUALTreeU d u a l) where
+  type O (DUALTreeU d u a l) = (u, DUALTreeNE d u a l)
   pack   = DUALTreeU
   unpack = unDUALTreeU
 
@@ -149,7 +152,8 @@ pullU t@(Annot _ (DUALTreeU (u, _))) = pack (u, t)
 newtype DUALTree d u a l = DUALTree { unDUALTree :: Option (DUALTreeU d u a l) }
   deriving ( Functor, Semigroup, Typeable, Show, Eq )
 
-instance Newtype (DUALTree d u a l) (Option (DUALTreeU d u a l)) where
+instance Newtype (DUALTree d u a l) where
+  type O (DUALTree d u a l) = Option (DUALTreeU d u a l)
   pack   = DUALTree
   unpack = unDUALTree
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,7 +8,7 @@ import           Data.Functor
 import           Data.Maybe
 import           Data.Typeable
 
-import           Test.QuickCheck
+import           Test.QuickCheck hiding ((===))
 import           Test.Feat
 
 import           Data.List.NonEmpty (NonEmpty)
@@ -43,12 +43,6 @@ buildTree (EAnnot a t) = annot a (buildTree t)
 
 instance Num a => Action (Product a) (Sum a) where
   act (Product p) (Sum s) = Sum (p * s)
-
-instance Arbitrary (Sum Int) where
-  arbitrary = Sum <$> arbitrary
-
-instance Arbitrary (Product Int) where
-  arbitrary = Product <$> arbitrary
 
 type U = Sum Int
 type D = Product Int
@@ -108,3 +102,6 @@ prop_act_mempty d = applyD d (mempty :: T) == mempty
 
 prop_act_mappend :: D -> T -> T -> Bool
 prop_act_mappend d t1 t2 = applyD d (t1 <> t2) === applyD d t1 <> applyD d t2
+
+return []
+main = $quickCheckAll


### PR DESCRIPTION
[newtype-generics](https://hackage.haskell.org/package/newtype-generics) is a replacement of `newtype`. this PR does the migration.

I also added testsuite declaration in .cabal file and adapted the code accordingly. just to show that the migration doesn't break intended behaviors.

Unfortunately `diagrams/diagrams-travis` is no longer working due to having to declare usage of `sudo` explicitly, and perhaps some other more travis-related problems. I won't bother dealing with more complications since the main purpose of this PR is just to replace newtype with newtype-generics.

Since travis is not keeping an eye on this, to test this PR, you could build the project and do `cabal test` or `stack test` manually.