### PR TITLE
Bump base for GHC 8.2

### DIFF
--- a/dual-tree.cabal
+++ b/dual-tree.cabal
@@ -40,7 +40,7 @@ library
   default-language:  Haskell2010
   exposed-modules:   Data.Tree.DUAL
                      Data.Tree.DUAL.Internal
-  build-depends:     base >= 4.3 && < 4.10,
+  build-depends:     base >= 4.3 && < 4.11,
                      semigroups >= 0.8 && < 0.19,
                      newtype-generics >= 0.5 && < 0.6,
                      monoid-extras >= 0.2 && < 0.5

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -52,8 +52,8 @@ instance Num a => Action (Product a) (Sum a) where
 type U = Sum Int
 type D = Product Int
 
-deriving instance Typeable1 Sum
-deriving instance Typeable1 Product
+deriving instance Typeable Sum
+deriving instance Typeable Product
 
 deriveEnumerable ''Sum
 deriveEnumerable ''Product


### PR DESCRIPTION
The package still builds and passes the
tests after the bump.

`Typeable1` has been deprecated since 7.8,
I replaced it with `Typeable`, otherwise it
wouldn't build.