### PR TITLE
Correct lower bound on newtype-generics

### DIFF
--- a/dual-tree.cabal
+++ b/dual-tree.cabal
@@ -42,7 +42,7 @@ library
                      Data.Tree.DUAL.Internal
   build-depends:     base >= 4.3 && < 4.12,
                      semigroups >= 0.8 && < 0.19,
-                     newtype-generics >= 0.5 && < 0.6,
+                     newtype-generics >= 0.5.3 && < 0.6,
                      monoid-extras >= 0.2 && < 0.6
   hs-source-dirs:    src
   other-extensions:  GeneralizedNewtypeDeriving,


### PR DESCRIPTION
As new Control.Newtype.Generics module is used, lower bound should be higher.

I made revision on Jackage, so no action there is required. http://hackage.haskell.org/package/dual-tree-0.2.2/revisions/

I also checked other lower bounds, and they seem right

```
                  7.0.4    7.2.2    7.4.2    7.6.3    7.8.4    7.10.3   8.0.2    8.2.2     8.4.1   
base              no-plan  no-plan  no-plan  4.6.0.1  4.7.0.2  4.8.2.0  4.9.1.0  4.10.1.0  4.11.0.0
monoid-extras     no-plan  no-plan  no-plan  0.2.0.0  0.2.2.3  0.4.0.0  0.4.0.4  0.4.2     0.4.3   
newtype-generics  no-plan  no-plan  no-plan  0.5.3    0.5.3    0.5.3    0.5.3    0.5.3     0.5.3   
semigroups        no-plan  no-plan  no-plan  0.15.2   0.8      0.8.3.1  0.18.1   0.18.1    0.18.1  
```

lower bound on `base` can be stricter too (now `>=4.3`) to better indicate what's tested, but that's completely optional.