### PR TITLE
Allow base 4.15.x for GHC 8.10

### DIFF
--- a/dual-tree.cabal
+++ b/dual-tree.cabal
@@ -40,7 +40,7 @@ library
   default-language:  Haskell2010
   exposed-modules:   Data.Tree.DUAL
                      Data.Tree.DUAL.Internal
-  build-depends:     base >= 4.3 && < 4.14,
+  build-depends:     base >= 4.3 && < 4.15,
                      semigroups >= 0.8 && < 0.20,
                      newtype-generics >= 0.5.3 && < 0.6,
                      monoid-extras >= 0.2 && < 0.6


### PR DESCRIPTION
Note that this requires using [master of monoid-extras](https://github.com/diagrams/monoid-extras), since the latest on Hackage does not work with GHC 8.10.